### PR TITLE
Public url for libffi submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libffi"]
 	path = libffi
-	url = git@github.com:ebf/libffi-iOS.git
+	url = git://github.com/ebf/libffi-iOS.git


### PR DESCRIPTION
I believe submodule url should be public so that non-github users could use main repo without problems too.
