### PR TITLE
NSMethodSignature can not handle quoted class names on iOS 5

### DIFF
--- a/CTObjectiveCRuntimeAdditions/CTObjectiveCRuntimeAdditions/CTBlockDescription.m
+++ b/CTObjectiveCRuntimeAdditions/CTObjectiveCRuntimeAdditions/CTBlockDescription.m
@@ -8,6 +8,25 @@
 
 #import "CTBlockDescription.h"
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_6_0
+NS_INLINE const char * remove_quoted_parts(const char *str){
+    char *result = malloc(strlen(str) + 1);
+    BOOL skip = NO;
+    char *to = result;
+    char c;
+    while ((c = *str++)) {
+        if ('"' == c) {
+            skip = !skip;
+            continue;
+        }
+        if (skip) continue;
+        *to++ = c;
+    }
+    *to = '\0';
+    return result;
+}
+#endif
+
 @implementation CTBlockDescription
 
 - (id)initWithBlock:(id)block
@@ -30,6 +49,12 @@
             }
             
             const char *signature = (*(const char **)signatureLocation);
+            
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_6_0
+            // NSMethodSignature on iOS 5 can not handle quoted class names
+            signature = remove_quoted_parts(signature);
+#endif
+            
             _blockSignature = [NSMethodSignature signatureWithObjCTypes:signature];
         }
     }

--- a/CTObjectiveCRuntimeAdditions/CTObjectiveCRuntimeAdditionsTests/CTObjectiveCRuntimeAdditionsTests.m
+++ b/CTObjectiveCRuntimeAdditions/CTObjectiveCRuntimeAdditionsTests/CTObjectiveCRuntimeAdditionsTests.m
@@ -45,6 +45,14 @@
     }
 }
 
+- (void)testBlockDescriptionCanHandleSpecifiedClasses{
+    NSString *(^testBlock)(NSString *) = ^NSString *(NSString *str) {
+        return @"Test";
+    };
+    
+    STAssertNoThrow([[CTBlockDescription alloc] initWithBlock:testBlock], @"CTBlockDescription fails when class names are specified.");
+}
+
 - (void)testBlockSwizzling
 {
     Class class = [CTTestSwizzleClass class];


### PR DESCRIPTION
See https://github.com/OliverLetterer/SLObjectiveCRuntimeAdditions/pull/2 for details.
